### PR TITLE
Maven 3 / Cover default test name compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>LATEST</version>
+			<version>2.13.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>LATEST</version>
+			<version>2.13.3</version>
 		</dependency>
 
 		<!-- @Inject -->

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
 				<version>2.20.1</version>
 				<configuration>
 					<includes>
+						<include>**/*Test.java</include>
 						<include>**/*Tests.java</include>
 					</includes>
 					<excludes>


### PR DESCRIPTION
Update to this benchmark based on findings in https://diffblue.atlassian.net/browse/TG-11622

- Set explicit versions for the log4j dependencies in order to work with Maven 3 out of the box
- Add an additional include filter to Surefire so that default Cover test names are included in `mvn test`

### QA Notes

#### Manual Test

1. Clone this branch of the repo
2. Run `mvn install` -> build is successful (this will fail on master)
3. Run `mvn test` -> will run 81 tests
4. Run `dcover create`
5. Run `mvn test` -> will run 208 tests (new tests will not be run on master)